### PR TITLE
Make color editable

### DIFF
--- a/block.json
+++ b/block.json
@@ -7,7 +7,10 @@
 	"category": "woocommerce",
 	"parent": [ "woocommerce/cart-totals-block" ],
 	"supports": {
-		"html": false
+		"html": false,
+		"color": {
+			"__experimentalSkipSerialization": true
+		}
 	},
 	"attributes": {
 		"currentTotal": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"start": "wp-scripts start",
-		"test": "wp-scripts test-unit-js",
-		"test:coverage": "wp-scripts test-unit-js --coverage",
+		"test": "wp-scripts test-unit-js --verbose",
+		"test:coverage": "wp-scripts test-unit-js --coverage --verbose",
 		"test:help": "wp-scripts test-unit-js --help",
 		"test:watch": "wp-scripts test-unit-js --watchAll",
 		"phpcbf": "composer run phpcbf",
@@ -32,7 +32,10 @@
 	"dependencies": {
 		"@wordpress/block-editor": "^8.0.0",
 		"@wordpress/blocks": "^11.1.0",
+		"autoprefixer": "10.4.2",
+		"classnames": "^2.3.1",
 		"eslint": "^7.32.0",
+		"lodash.kebabcase": "^4.1.1",
 		"prettier": "npm:wp-prettier@2.0.5"
 	},
 	"devDependencies": {

--- a/src/block.js
+++ b/src/block.js
@@ -6,9 +6,9 @@ import ProgressBar from './components/progress-bar';
 
 export default function Block( attributes ) {
 	return (
-		<>
+		<div className="wc-free-shipping-progress-bar">
 			<ProgressLabel { ...attributes } />
 			<ProgressBar { ...attributes } />
-		</>
+		</div>
 	);
 }

--- a/src/components/progress-bar/__test__/index.test.js
+++ b/src/components/progress-bar/__test__/index.test.js
@@ -7,39 +7,53 @@ import '@testing-library/jest-dom';
 /**
  * Internal dependencies
  */
-import ProgressBar from './../index';
+import ProgressBar from '../index';
 
-const outer = '.wc-free-shipping-progress-bar__outer';
-const inner = '.wc-free-shipping-progress-bar__inner';
+const progressbar = '.wc-free-shipping-progress-bar__progress';
 
 describe( 'The ProgressBar component', () => {
-	it( 'shows the classnames of the outer div correctly', () => {
-		render( <ProgressBar /> );
-		expect( document.querySelector( outer ) ).toBeInTheDocument();
-	} );
-
-	it( 'shows the classnames of the inner div correctly', () => {
-		render( <ProgressBar /> );
-		expect( document.querySelector( inner ) ).toBeInTheDocument();
+	it( 'shows the classnames of the div correctly', () => {
+		render( <ProgressBar freeShippingFrom="1" currentTotal="0" /> );
+		expect( document.querySelector( progressbar ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the style for a full bar correctly', () => {
 		render( <ProgressBar freeShippingFrom="4" currentTotal="4" /> );
-		expect( document.querySelector( inner ) ).toHaveStyle( 'width: 100%' );
+		expect( document.querySelector( progressbar ) ).toHaveAttribute(
+			'value',
+			'100'
+		);
 	} );
 
-	it( 'shows the style for a threequarter bar correctly', () => {
+	it( 'shows the style for a three quarter bar correctly', () => {
 		render( <ProgressBar freeShippingFrom="4" currentTotal="3" /> );
-		expect( document.querySelector( inner ) ).toHaveStyle( 'width: 75%' );
+		expect( document.querySelector( progressbar ) ).toHaveAttribute(
+			'value',
+			'75'
+		);
 	} );
 
 	it( 'shows the style for a half bar correctly', () => {
 		render( <ProgressBar freeShippingFrom="4" currentTotal="2" /> );
-		expect( document.querySelector( inner ) ).toHaveStyle( 'width: 50%' );
+		expect( document.querySelector( progressbar ) ).toHaveAttribute(
+			'value',
+			'50'
+		);
+	} );
+
+	it( 'shows the style for a one quarter bar correctly', () => {
+		render( <ProgressBar freeShippingFrom="4" currentTotal="1" /> );
+		expect( document.querySelector( progressbar ) ).toHaveAttribute(
+			'value',
+			'25'
+		);
 	} );
 
 	it( 'shows the style for an empty bar correctly', () => {
 		render( <ProgressBar freeShippingFrom="4" currentTotal="0" /> );
-		expect( document.querySelector( inner ) ).toHaveStyle( 'width: 0%' );
+		expect( document.querySelector( progressbar ) ).toHaveAttribute(
+			'value',
+			'0'
+		);
 	} );
 } );

--- a/src/components/progress-bar/index.js
+++ b/src/components/progress-bar/index.js
@@ -1,15 +1,39 @@
-const ProgressBar = ( { currentTotal, freeShippingFrom } ) => {
+/*
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { getColorClass, getColorCode } from '../../util';
+
+const ProgressBar = ( {
+	currentTotal,
+	freeShippingFrom,
+	backgroundColor,
+	colorProps,
+} ) => {
+	const progressClass = getColorClass( backgroundColor, 'color' );
+	const progressColor = getColorCode(
+		backgroundColor,
+		colorProps,
+		'backgroundColor'
+	);
 	const progress = ( currentTotal / freeShippingFrom ) * 100;
-	const divWidth = ( progress > 100 ? 100 : progress ) + '%';
-	const divStyle = { width: divWidth };
+	const width = progress > 100 ? 100 : progress;
+	const style = { color: progressColor };
 
 	return (
-		<div className="wc-free-shipping-progress-bar__outer">
-			<div
-				className="wc-free-shipping-progress-bar__inner"
-				style={ divStyle }
-			></div>
-		</div>
+		<progress
+			className={ classnames(
+				'wc-free-shipping-progress-bar__progress',
+				progressClass
+			) }
+			max="100"
+			style={ style }
+			value={ width }
+		/>
 	);
 };
 

--- a/src/components/progress-label/index.js
+++ b/src/components/progress-label/index.js
@@ -1,9 +1,24 @@
+/*
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { getColorClass, getColorCode } from '../../util';
+
 const ProgressLabel = ( {
 	currentTotal,
 	freeShippingFrom,
 	labelInsufficientTotals,
 	labelSufficientTotals,
+	textColor,
+	colorProps,
 } ) => {
+	const messageClass = getColorClass( textColor, 'color' );
+	const messageColor = getColorCode( textColor, colorProps, 'color' );
+	const style = { color: messageColor };
 	const remaining = Number( freeShippingFrom - currentTotal ).toFixed( 2 );
 	const message =
 		remaining > 0
@@ -11,7 +26,15 @@ const ProgressLabel = ( {
 			: labelSufficientTotals;
 
 	return (
-		<div className="wc-free-shipping-progress-bar__label">{ message }</div>
+		<div
+			className={ classnames(
+				'wc-free-shipping-progress-bar__label',
+				messageClass
+			) }
+			style={ style }
+		>
+			{ message }
+		</div>
 	);
 };
 

--- a/src/edit.js
+++ b/src/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	__experimentalUseColorProps as useColorProps,
 	BlockControls,
 	InspectorControls,
 	PlainText,
@@ -19,6 +20,7 @@ import useViewSwitcher from './components/use-view-switcher';
 import { notice } from './constants';
 import { Icon, progressBarHalf, progressBarFull } from './icons';
 import './style.scss';
+import { getColorCode } from './util';
 
 const BlockSettings = ( { attributes, setAttributes } ) => {
 	const { freeShippingFrom } = attributes;
@@ -51,7 +53,11 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 };
 
 const Edit = ( { attributes, setAttributes, clientId } ) => {
-	const { labelInsufficientTotals, labelSufficientTotals } = attributes;
+	const {
+		labelInsufficientTotals,
+		labelSufficientTotals,
+		textColor,
+	} = attributes;
 	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher(
 		clientId,
 		[
@@ -73,6 +79,10 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			},
 		]
 	);
+
+	const colorProps = useColorProps( attributes );
+	const messageColor = getColorCode( textColor, colorProps, 'color' );
+	const messageStyle = { color: messageColor };
 
 	return (
 		<div { ...useBlockProps() }>
@@ -102,6 +112,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						/>
 						<PlainText
 							className="wc-free-shipping-progress-bar__label"
+							style={ messageStyle }
 							value={ labelInsufficientTotals }
 							onChange={ ( value ) =>
 								setAttributes( {
@@ -135,13 +146,18 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 								</p>
 							</Notice>
 						) }
-						<ProgressBar { ...attributes } />
+
+						<ProgressBar
+							{ ...attributes }
+							colorProps={ colorProps }
+						/>
 					</>
 				) }
 				{ currentView === 'sufficient-cart-totals' && (
 					<>
 						<PlainText
 							className="wc-free-shipping-progress-bar__label"
+							style={ messageStyle }
 							value={ labelSufficientTotals }
 							onChange={ ( value ) =>
 								setAttributes( {
@@ -151,6 +167,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						/>
 						<ProgressBar
 							{ ...attributes }
+							colorProps={ colorProps }
 							currentTotal="1"
 							freeShippingFrom="1"
 						/>

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,19 +1,21 @@
-.wc-free-shipping-progress-bar__outer {
-	align-items: center;
+.wc-free-shipping-progress-bar__progress[value] {
+	appearance: none;
 	background: transparent;
-	border: 2px solid #ddd;
-	border-radius: 4px;
-	display: flex;
-	height: 2em;
-	justify-content: center;
-	margin: 0.5em 0 2em;
-	padding: 0.1em;
-	position: relative;
-}
-.wc-free-shipping-progress-bar__inner {
-	background: #4c566a;
+	border: 1px solid currentColor;
 	border-radius: 3px;
-	height: 100%;
-	left: 0;
-	position: absolute;
+	height: 20px;
+	margin: 0.5em 0 2em;
+	width: 100%;
+}
+
+.wc-free-shipping-progress-bar__progress[value]::-webkit-progress-bar {
+	background: transparent;
+}
+
+.wc-free-shipping-progress-bar__progress[value]::-webkit-progress-value {
+	background: currentColor;
+}
+
+.wc-free-shipping-progress-bar__progress[value]::-moz-progress-bar {
+	background: currentColor;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import kebabCase from 'lodash.kebabcase';
+
+export function getColorClass( colorSlug, colorContextName ) {
+	if ( ! colorSlug || ! colorContextName ) {
+		return undefined;
+	}
+
+	return `has-${ kebabCase(
+		colorSlug
+	) }-${ colorContextName } has-text-color`;
+}
+
+export function getColorCode( colorCode, colorProps, scope ) {
+	if ( colorProps !== undefined && colorProps.style !== undefined ) {
+		return colorProps.style[ scope ];
+	}
+
+	return colorCode || 'currentColor';
+}

--- a/woocommerce-free-shipping-progress-bar-block.php
+++ b/woocommerce-free-shipping-progress-bar-block.php
@@ -24,21 +24,18 @@ defined( 'ABSPATH' ) || exit;
  * through the block editor in the corresponding context.
  *
  * @see https://developer.wordpress.org/block-editor/tutorials/block-tutorial/writing-your-first-block-type/
- * @return void
  */
 function create_block_interactive_block_block_init() {
 	register_block_type(
 		__DIR__,
 		array(
-			'render_callback' => 'render_block_with_attribures',
+			'render_callback' => 'render_block_with_attributes',
 		)
 	);
 }
 
 /**
- * Enqueue frontend scripts.
- *
- * @return void
+ * Enqueue the frontend scripts.
  */
 function enqueue_frontend_script() {
 	$script_path       = 'build/frontend.js';
@@ -49,22 +46,38 @@ function enqueue_frontend_script() {
 }
 
 /**
- * Add attributes to the block.
+ * Add attributes to block.
  *
- * @param array  $attributes The attributes to add.
- * @param string $content The original content.
- * @return string The updated content.
+ * @param array  $attributes    The array with attributes.
+ * @param string $content       The original block HTML code.
+ * @return string               The updated block HTML code.
  */
 function add_attributes_to_block( $attributes = array(), $content = '' ) {
 	$escaped_data_attributes = array();
 
+	// Add the custom background color to the attributes array.
+	if ( ! $attributes['backgroundColor'] && isset( $attributes['style'], $attributes['style']['color'], $attributes['style']['color']['background'] ) ) {
+		$attributes['backgroundColor'] = $attributes['style']['color']['background'];
+	}
+
+	// Add the custom text color to the attributes array.
+	if ( ! $attributes['textColor'] && isset( $attributes['style'], $attributes['style']['color'], $attributes['style']['color']['text'] ) ) {
+		$attributes['textColor'] = $attributes['style']['color']['text'];
+	}
+
 	foreach ( $attributes as $key => $value ) {
+		if ( 'style' === $key ) {
+			continue;
+		}
+
 		if ( is_bool( $value ) ) {
 			$value = $value ? 'true' : 'false';
 		}
+
 		if ( ! is_scalar( $value ) ) {
 			$value = wp_json_encode( $value );
 		}
+
 		$escaped_data_attributes[] = 'data-' . esc_attr( strtolower( preg_replace( '/(?<!\ )[A-Z]/', '-$0', $key ) ) ) . '="' . esc_attr( $value ) . '"';
 	}
 
@@ -72,25 +85,25 @@ function add_attributes_to_block( $attributes = array(), $content = '' ) {
 }
 
 /**
- * Render attributes with attributes
+ * Render block with attributes.
  *
- * @param array  $attributes The attributes to add.
- * @param string $content The original content.
- * @return string The updated content.
+ * @param array  $attributes    The array with attributes.
+ * @param string $content       The original block HTML code.
+ * @return string               The updated block HTML code.
  */
-function render_block_with_attribures( $attributes = array(), $content = '' ) {
+function render_block_with_attributes( $attributes = array(), $content = '' ) {
 	if ( ! is_admin() ) {
 		enqueue_frontend_script();
 	}
 	return add_attributes_to_block( $attributes, $content );
 };
+
 add_action( 'init', 'create_block_interactive_block_block_init' );
 
 /**
  * Add experimentalfilter to add data attributes to the free shipping progress bar block.
  *
  * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/blocks/feature-flags-and-experimental-interfaces.md
- * @return void
  */
 add_filter(
 	'__experimental_woocommerce_blocks_add_data_attributes_to_block',


### PR DESCRIPTION
Fixes #6 

## Note

In i1 of this block, the merchant must be able to select the color of the message and the progress bar. This PR aims to add this functionality.

## Screenshots

### Named colors

<table>
<tr>
<td valign="top">Editor:
<br><br>

![#14-editor-named-colors](https://user-images.githubusercontent.com/3323310/141120420-c2d15a35-53ec-4b68-858d-6f77fa112b5a.png)
</td>
<td valign="top">Frontend:
<br><br>

![#14-frontend-named-colors](https://user-images.githubusercontent.com/3323310/141120430-baccc475-a787-472c-b26b-e160c5193719.png)
</td>
</tr>
</table>

### Custom colors

<table>
<tr>
<td valign="top">Editor:
<br><br>

![#14-editor-custom-colors](https://user-images.githubusercontent.com/3323310/141120384-a22b03e1-c7df-44fd-8c32-e5087f4e6762.png)
</td>
<td valign="top">Frontend:
<br><br>

![#14-frontend-custom-colors](https://user-images.githubusercontent.com/3323310/141120422-113b19c3-603d-427c-9d36-ef8db2593e99.png)
</td>
</tr>
</table>

## Test instructions

* Check out this PR.
* Create a test page.
* Add the block Free Shipping Progress Bar to the test page.
* Click on the block to open the Inspector Controls.
* Adjust the message color and the progress bar color using named colors.
* Ensure that the color change in the editor.
* Save the test page.
* Ensure that the color change in the frontend.
* Adjust the message color and the progress bar color using custom colors.
* Ensure that the color change in the editor.
* Save the test page.
* Ensure that the color change in the frontend.