### PR TITLE
Make message editable

### DIFF
--- a/block.json
+++ b/block.json
@@ -11,12 +11,20 @@
 	},
 	"attributes": {
 		"currentTotal": {
-			"type": "number",
+			"type": "string",
 			"default": "15"
 		},
 		"freeShippingFrom": {
-			"type": "number",
+			"type": "string",
 			"default": "50"
+		},
+		"labelInsufficientTotals": {
+			"type": "string",
+			"default": "Spend only {amount} more to get free shipping!"
+		},
+		"labelSufficientTotals": {
+			"type": "string",
+			"default": "You have qualified for free shipping. Great job!"
 		}
 	},
 	"textdomain": "free-shipping-progress-bar",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"prettier": "npm:wp-prettier@2.0.5"
 	},
 	"devDependencies": {
+		"@wordpress/components": "^18.0.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
 		"@wordpress/i18n": "4.2.4",
 		"@wordpress/prettier-config": "1.1.1",

--- a/src/block.js
+++ b/src/block.js
@@ -1,33 +1,14 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import ProgressLabel from './components/progress-label';
+import ProgressBar from './components/progress-bar';
 
-export default function Block( { currentTotal, freeShippingFrom } ) {
-	const progress = ( currentTotal / freeShippingFrom ) * 100;
-	const divWidth = ( progress > 100 ? 100 : progress ) + '%';
-	const divStyle = { width: divWidth };
-	const remaining = Number( freeShippingFrom - currentTotal ).toFixed( 2 );
-	const message =
-		remaining > 0
-			? sprintf(
-					__(
-						'Spend only $%s more to get free shipping!',
-						'free-shipping-progress-bar'
-					),
-					remaining
-			  )
-			: __(
-					'You have qualified for free shipping. Great job!',
-					'free-shipping-progress-bar'
-			  );
-
+export default function Block( attributes ) {
 	return (
-		<div className="wc-free-shipping-progress-bar">
-			<div id="message">{ message }</div>
-			<div id="progressBar">
-				<div id="progress" style={ divStyle }></div>
-			</div>
-		</div>
+		<>
+			<ProgressLabel { ...attributes } />
+			<ProgressBar { ...attributes } />
+		</>
 	);
 }

--- a/src/components/block-error-boundary/block-error.js
+++ b/src/components/block-error-boundary/block-error.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const BlockError = ( {
+	header = __( 'Oops!', 'free-shipping-progress-bar' ),
+	text = __(
+		'There was an error loading the content.',
+		'free-shipping-progress-bar'
+	),
+	errorMessage,
+	errorMessagePrefix = __( 'Error:', 'free-shipping-progress-bar' ),
+	button,
+} ) => {
+	return (
+		<div className="wc-free-shipping-progress-bar-error">
+			<div className="wc-free-shipping-progress-bar-error__content">
+				{ header && (
+					<p className="wc-free-shipping-progress-bar-error__header">
+						{ header }
+					</p>
+				) }
+				{ text && (
+					<p className="wc-free-shipping-progress-bar-error__text">
+						{ text }
+					</p>
+				) }
+				{ errorMessage && (
+					<p className="wc-free-shipping-progress-bar-error__message">
+						{ errorMessagePrefix ? errorMessagePrefix + ' ' : '' }
+						{ errorMessage }
+					</p>
+				) }
+				{ button && (
+					<p className="wc-free-shipping-progress-bar-error__button">
+						{ button }
+					</p>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default BlockError;

--- a/src/components/block-error-boundary/index.js
+++ b/src/components/block-error-boundary/index.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import BlockError from './block-error';
+import './style.scss';
+
+class BlockErrorBoundary extends Component {
+	state = { errorMessage: '', hasError: false };
+
+	static getDerivedStateFromError( error ) {
+		if (
+			typeof error.statusText !== 'undefined' &&
+			typeof error.status !== 'undefined'
+		) {
+			return {
+				errorMessage: (
+					<>
+						<strong>{ error.status }</strong>:&nbsp;
+						{ error.statusText }
+					</>
+				),
+				hasError: true,
+			};
+		}
+
+		return { errorMessage: error.message, hasError: true };
+	}
+
+	render() {
+		const {
+			header,
+			showErrorMessage,
+			text,
+			errorMessagePrefix,
+			renderError,
+			button,
+		} = this.props;
+		const { errorMessage, hasError } = this.state;
+
+		if ( hasError ) {
+			if ( typeof renderError === 'function' ) {
+				return renderError( { errorMessage } );
+			}
+			return (
+				<BlockError
+					errorMessage={ showErrorMessage ? errorMessage : null }
+					header={ header }
+					text={ text }
+					errorMessagePrefix={ errorMessagePrefix }
+					button={ button }
+				/>
+			);
+		}
+
+		return this.props.children;
+	}
+}
+
+export default BlockErrorBoundary;

--- a/src/components/block-error-boundary/style.scss
+++ b/src/components/block-error-boundary/style.scss
@@ -1,0 +1,28 @@
+.wc-free-shipping-progress-bar-error {
+	align-items: center;
+	color: currentColor;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	margin: 1em;
+	padding: 1em;
+	text-align: center;
+}
+.wc-free-shipping-progress-bar-error__header {
+	color: currentColor;
+	margin: 0;
+}
+.wc-free-shipping-progress-bar-error__text {
+	color: currentColor;
+	margin: 1em 0 0;
+	max-width: 60ch;
+}
+.wc-free-shipping-progress-bar-error__message {
+	color: currentColor;
+	font-style: italic;
+	margin: 1em 0 0;
+	max-width: 60ch;
+}
+.wc-free-shipping-progress-bar-error__button {
+	margin: 0;
+}

--- a/src/components/progress-bar/index.js
+++ b/src/components/progress-bar/index.js
@@ -1,0 +1,16 @@
+const ProgressBar = ( { currentTotal, freeShippingFrom } ) => {
+	const progress = ( currentTotal / freeShippingFrom ) * 100;
+	const divWidth = ( progress > 100 ? 100 : progress ) + '%';
+	const divStyle = { width: divWidth };
+
+	return (
+		<div className="wc-free-shipping-progress-bar__outer">
+			<div
+				className="wc-free-shipping-progress-bar__inner"
+				style={ divStyle }
+			></div>
+		</div>
+	);
+};
+
+export default ProgressBar;

--- a/src/components/progress-label/index.js
+++ b/src/components/progress-label/index.js
@@ -1,0 +1,18 @@
+const ProgressLabel = ( {
+	currentTotal,
+	freeShippingFrom,
+	labelInsufficientTotals,
+	labelSufficientTotals,
+} ) => {
+	const remaining = Number( freeShippingFrom - currentTotal ).toFixed( 2 );
+	const message =
+		remaining > 0
+			? labelInsufficientTotals.replace( '{amount}', remaining )
+			: labelSufficientTotals;
+
+	return (
+		<div className="wc-free-shipping-progress-bar__label">{ message }</div>
+	);
+};
+
+export default ProgressLabel;

--- a/src/components/use-view-switcher/index.js
+++ b/src/components/use-view-switcher/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { useDispatch, select } from '@wordpress/data';
+import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { Icon, eye } from '../../icons';
+
+export const useViewSwitcher = ( clientId, views ) => {
+	const initialView = views[ 0 ];
+	const [ currentView, setCurrentView ] = useState( initialView );
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { getBlock } = select( blockEditorStore );
+
+	const ViewSwitcherComponent = (
+		<Toolbar>
+			<ToolbarDropdownMenu
+				label={ __( 'Switch view', 'free-shipping-progress-bar' ) }
+				text={ currentView.label }
+				icon={
+					<Icon srcElement={ eye } style={ { marginRight: '8px' } } />
+				}
+				controls={ views.map( ( view ) => ( {
+					...view,
+					title: view.label,
+					onClick: () => {
+						setCurrentView( view );
+						selectBlock(
+							getBlock( clientId ).innerBlocks.find(
+								( block ) => block.name === view.view
+							)?.clientId || clientId
+						);
+					},
+				} ) ) }
+			/>
+		</Toolbar>
+	);
+
+	return {
+		currentView: currentView.view,
+		component: ViewSwitcherComponent,
+	};
+};
+
+export default useViewSwitcher;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const notice = __(
+	'Spend only {amount} more to get free shipping!',
+	'free-shipping-progress-bar'
+);

--- a/src/edit.js
+++ b/src/edit.js
@@ -2,43 +2,163 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import {
+	BlockControls,
+	InspectorControls,
+	PlainText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { Notice, PanelBody, TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import Block from './block';
+import BlockErrorBoundary from './components/block-error-boundary';
+import ProgressBar from './components/progress-bar';
+import useViewSwitcher from './components/use-view-switcher';
+import { notice } from './constants';
+import { Icon, progressBarHalf, progressBarFull } from './icons';
+import './style.scss';
 
-export default function Edit( { attributes, setAttributes } ) {
+const BlockSettings = ( { attributes, setAttributes } ) => {
 	const { freeShippingFrom } = attributes;
 
 	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Settings', 'free-shipping-progress-bar' ) }
+				initialOpen={ true }
+			>
+				<TextControl
+					label={ __(
+						'Free shipping from',
+						'free-shipping-progress-bar'
+					) }
+					help={ __(
+						'Provide the value in your store currency.',
+						'free-shipping-progress-bar'
+					) }
+					value={ freeShippingFrom }
+					onChange={ ( value ) =>
+						setAttributes( {
+							freeShippingFrom: value,
+						} )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+const Edit = ( { attributes, setAttributes, clientId } ) => {
+	const { labelInsufficientTotals, labelSufficientTotals } = attributes;
+	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher(
+		clientId,
+		[
+			{
+				view: 'insufficient-cart-totals',
+				label: __(
+					'Insufficient cart totals',
+					'free-shipping-progress-bar'
+				),
+				icon: <Icon srcElement={ progressBarHalf } />,
+			},
+			{
+				view: 'sufficient-cart-totals',
+				label: __(
+					'Sufficient cart totals',
+					'free-shipping-progress-bar'
+				),
+				icon: <Icon srcElement={ progressBarFull } />,
+			},
+		]
+	);
+
+	return (
 		<div { ...useBlockProps() }>
-			<InspectorControls>
-				<PanelBody
-					title={ __( 'Settings', 'free-shipping-progress-bar' ) }
-					initialOpen={ true }
-				>
-					<TextControl
-						label={ __(
-							'Free shipping from',
-							'free-shipping-progress-bar'
+			<BlockErrorBoundary
+				header={ __(
+					'Progress Bar Block Error',
+					'free-shipping-progress-bar'
+				) }
+				text={ __(
+					'There was an error whilst editing the progress bar block. If this problem continues, try re-creating the block.',
+					'free-shipping-progress-bar'
+				) }
+				showErrorMessage={ true }
+				errorMessagePrefix={ __(
+					'Error message:',
+					'free-shipping-progress-bar'
+				) }
+			>
+				<BlockControls __experimentalShareWithChildBlocks>
+					{ ViewSwitcherComponent }
+				</BlockControls>
+				{ currentView === 'insufficient-cart-totals' && (
+					<>
+						<BlockSettings
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
+						<PlainText
+							className="wc-free-shipping-progress-bar__label"
+							value={ labelInsufficientTotals }
+							onChange={ ( value ) =>
+								setAttributes( {
+									labelInsufficientTotals: value,
+								} )
+							}
+						/>
+						{ ! labelInsufficientTotals.includes( '{amount}' ) && (
+							<Notice
+								className="wc-free-shipping-progress-bar__notice"
+								status="warning"
+								isDismissible={ false }
+								actions={ [
+									{
+										label: __(
+											'Restore default text',
+											'free-shipping-progress-bar'
+										),
+										onClick: () =>
+											setAttributes( {
+												labelInsufficientTotals: notice,
+											} ),
+									},
+								] }
+							>
+								<p>
+									{ __(
+										'Ensure that the label contains the placeholder {amount}.',
+										'free-shipping-progress-bar'
+									) }
+								</p>
+							</Notice>
 						) }
-						help={ __(
-							'Provide the value in your store currency.',
-							'free-shipping-progress-bar'
-						) }
-						value={ freeShippingFrom }
-						onChange={ ( value ) =>
-							setAttributes( {
-								freeShippingFrom: value,
-							} )
-						}
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<Block { ...attributes } />
+						<ProgressBar { ...attributes } />
+					</>
+				) }
+				{ currentView === 'sufficient-cart-totals' && (
+					<>
+						<PlainText
+							className="wc-free-shipping-progress-bar__label"
+							value={ labelSufficientTotals }
+							onChange={ ( value ) =>
+								setAttributes( {
+									labelSufficientTotals: value,
+								} )
+							}
+						/>
+						<ProgressBar
+							{ ...attributes }
+							currentTotal="1"
+							freeShippingFrom="1"
+						/>
+					</>
+				) }
+			</BlockErrorBoundary>
 		</div>
 	);
-}
+};
+
+export default Edit;

--- a/src/icons/icon/index.js
+++ b/src/icons/icon/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { cloneElement, isValidElement } from '@wordpress/element';
+
+const Icon = ( { srcElement, size = 24, ...props } ) => {
+	if ( ! isValidElement( srcElement ) ) {
+		return null;
+	}
+	return cloneElement( srcElement, {
+		width: size,
+		height: size,
+		...props,
+	} );
+};
+
+export default Icon;

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,0 +1,5 @@
+export { default as Icon } from './icon';
+
+export { default as eye } from './library/eye';
+export { default as progressBarHalf } from './library/progress-bar-half';
+export { default as progressBarFull } from './library/progress-bar-full';

--- a/src/icons/library/eye.js
+++ b/src/icons/library/eye.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { SVG } from '@wordpress/components';
+
+const eye = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<path fill="none" d="M0 0h24v24H0V0z" />
+		<path d="M12 6a9.77 9.77 0 0 1 8.82 5.5C19.17 14.87 15.79 17 12 17s-7.17-2.13-8.82-5.5A9.77 9.77 0 0 1 12 6m0-2C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4zm0 5a2.5 2.5 0 0 1 0 5 2.5 2.5 0 0 1 0-5m0-2c-2.48 0-4.5 2.02-4.5 4.5S9.52 16 12 16s4.5-2.02 4.5-4.5S14.48 7 12 7z" />
+	</SVG>
+);
+
+export default eye;

--- a/src/icons/library/progress-bar-full.js
+++ b/src/icons/library/progress-bar-full.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { SVG } from '@wordpress/components';
+
+const progressBarFull = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+		<path
+			d="M3 6H17Q19 6 19 8Q19 10 19 12Q19 14 17 14L3 14Q1 14 1 12L1 8Q1 6 3 6"
+			fill="none"
+			stroke="#7F54B3"
+			stroke-width="1"
+		/>
+		<path fill="#7F54B3" d="M3 8 17 8 17 12 3 12Z" />
+	</SVG>
+);
+
+export default progressBarFull;

--- a/src/icons/library/progress-bar-half.js
+++ b/src/icons/library/progress-bar-half.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { SVG } from '@wordpress/components';
+
+const progressBarHalf = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+		<path
+			d="M3 6H17Q19 6 19 8Q19 10 19 12Q19 14 17 14L3 14Q1 14 1 12L1 8Q1 6 3 6"
+			fill="none"
+			stroke="#7F54B3"
+			stroke-width="1"
+		/>
+		<path fill="#7F54B3" d="M3 8 10 8 10 12 3 12Z" />
+	</SVG>
+);
+
+export default progressBarHalf;

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import './style.scss';
 /**
  * Internal dependencies
  */
-import ProgressBarIcon from './progress-bar-icon';
+import { Icon, progressBarHalf } from './icons';
 import Edit from './edit';
 import save from './save';
 
@@ -25,7 +25,8 @@ registerBlockType( 'nielslange/free-shipping-progress-bar', {
 	/**
 	 * @see ./progress-bar-icon.js
 	 */
-	icon: <ProgressBarIcon />,
+	icon: <Icon srcElement={ progressBarHalf } />,
+
 	/**
 	 * @see ./edit.js
 	 */

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,22 +1,19 @@
-.wc-free-shipping-progress-bar {
-	#progressBar {
-		align-items: center;
-		background: transparent;
-		border: 1px solid #ddd;
-		border-radius: 4px;
-		display: flex;
-		height: 2em;
-		justify-content: center;
-		margin: 0.5em 0 2em;
-		padding: 0.1em;
-		position: relative;
-
-		#progress {
-			background: #4c566a;
-			border-radius: 4px;
-			height: 100%;
-			left: 0;
-			position: absolute;
-		}
-	}
+.wc-free-shipping-progress-bar__outer {
+	align-items: center;
+	background: transparent;
+	border: 2px solid #ddd;
+	border-radius: 4px;
+	display: flex;
+	height: 2em;
+	justify-content: center;
+	margin: 0.5em 0 2em;
+	padding: 0.1em;
+	position: relative;
+}
+.wc-free-shipping-progress-bar__inner {
+	background: #4c566a;
+	border-radius: 3px;
+	height: 100%;
+	left: 0;
+	position: absolute;
 }


### PR DESCRIPTION
Fixes #4 

## Note

In i1 of this block, the merchant must be able to edit the messages for insufficient and sufficient cart totals. This PR adds this functionality.

<table>
<tr>
<td>Before:
<br><br>

![#4-before](https://user-images.githubusercontent.com/3323310/135429630-8c3043bc-d1b8-4696-bc8f-c7626cd8695a.png)
</td>
<td>After (separated textareas):
<br><br>

![#4-after-seperated](https://user-images.githubusercontent.com/3323310/135429763-e82ba0ca-568b-4cf6-96c7-060b72738869.png)
</td>
<td>After (combined textarea):
<br><br>

![#4-after-combined](https://user-images.githubusercontent.com/3323310/135429776-60419e24-7b2b-4ed2-983e-5e9ee17a5c9d.png)
</td>
</tr>
</table>

To enable merchants to adjust the message for insufficient cart totals, e.g. `Spend only $35.00 more to get free US shipping!`, according to their needs, I initially created two textareas. One textarea for the message before the remaining value and another one for the message after the remaining value. To keep the editing of the messages simple, I decided against that solution and created just one textarea to adjust the message for insufficient cart totals. This message includes the placeholder `%s`. In the help text, I highlighted the importance of this placeholder.

I created the two tags [Insufficient-totals-with-separate-textareas](https://github.com/woocommerce/woocommerce-free-shipping-progress-bar-block/releases/tag/Insufficient-totals-with-seperate-textareas) and [Insufficient-totals-with-combined-textarea](https://github.com/woocommerce/woocommerce-free-shipping-progress-bar-block/releases/tag/Insufficient-totals-with-one-textarea) so that both versions can be checked during the code review.

## Testing instructions

1. Check out this PR.
2. Create a test page.
3. Add the Free Shipping Progress Bar block to it and save the page.
4. Mark the block and open the sidebar.
5. Change the `Insufficient totals message` and `Sufficient totals message`.
6. Change the `Free shipping from` value to see both messages.
7. Ensure that the changes are visible both in the editor and the frontend.