### PR TITLE
Correct spelling of WooCommerce in readme.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-=== Woocommerce Free Shipping Progress Bar Block ===
+=== WooCommerce Free Shipping Progress Bar Block ===
 
 Contributors: automattic, woocommerce, nielslange
 Tags: free shipping progress bar, woocommerce, gutenberg


### PR DESCRIPTION
## Note

In README.txt, WooCommerce was misspelled. This PR corrects this typo by changing `Woocommerce` to `WooCommerce`.